### PR TITLE
데이터베이스 접근 로직 구현

### DIFF
--- a/project-board/src/main/java/fc/projectboard/domain/Article.java
+++ b/project-board/src/main/java/fc/projectboard/domain/Article.java
@@ -26,7 +26,7 @@ import java.util.Set;
 })
 @EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Article {
+public class Article extends AuditingField{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/project-board/src/main/java/fc/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/fc/projectboard/domain/ArticleComment.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 })
 @EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingField{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,17 +30,6 @@ public class ArticleComment {
     private Article article; //게시글 (ID)
     @Setter @Column(nullable = false,length = 500)
     private String content; // 내용
-    @CreatedDate @Column(nullable = false)
-    private LocalDateTime createdAt; // 생성일시
-
-    @CreatedBy @Column(nullable = false,length = 100)
-    private String createdBy; // 생성자
-
-    @LastModifiedDate @Column(nullable = false)
-    private LocalDateTime modifiedAt; // 수정일시
-
-    @LastModifiedBy @Column(nullable = false,length = 100)
-    private String modifiedBy; // 수정자
 
     protected ArticleComment() {
     }

--- a/project-board/src/main/java/fc/projectboard/domain/AuditingField.java
+++ b/project-board/src/main/java/fc/projectboard/domain/AuditingField.java
@@ -1,0 +1,41 @@
+package fc.projectboard.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingField{
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false,updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @CreatedBy
+    @Column(nullable = false,length = 100,updatable = false)
+    private String createdBy; // 생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false,length = 100)
+    private String modifiedBy; // 수정자
+
+}


### PR DESCRIPTION
생성자, 생성일시,수정자,수정일시는 반복적으로
앤티티에 들어가는 요소, 도메인과는 직접관계없으므로 추출
`@MappedSuperClass` 사용하여 상속방식으로 추출

`@DateTimeFormat` 요소 추가

this closes #5 